### PR TITLE
Remove warning

### DIFF
--- a/lib/impl/string.ex
+++ b/lib/impl/string.ex
@@ -73,7 +73,7 @@ defimpl Digger, for: BitString do
   end
 
   defp uppercase_first_for_camelize(string, :upper) do
-    remainder = String.slice(string, 1..-1)
+    remainder = String.slice(string, 1..-1//-1)
 
     string
     |> String.first()
@@ -82,7 +82,7 @@ defimpl Digger, for: BitString do
   end
 
   defp uppercase_first_for_camelize(string, _first_letter) do
-    remainder = String.slice(string, 1..-1)
+    remainder = String.slice(string, 1..-1//-1)
 
     string
     |> String.first()
@@ -113,7 +113,7 @@ defimpl Digger, for: BitString do
   defp lower_first(string, _), do: string
 
   defp to_lower(string) do
-    remainder = String.slice(string, 1..-1)
+    remainder = String.slice(string, 1..-1//-1)
 
     string
     |> String.first()
@@ -143,7 +143,7 @@ defimpl Digger, for: BitString do
   # for upcase_first/2
 
   defp uppercase_first_for_upcase(string, type: :value, key_transform: _, value_transform: :upper) do
-    remainder = String.slice(string, 1..-1)
+    remainder = String.slice(string, 1..-1//-1)
 
     string
     |> String.first()
@@ -152,7 +152,7 @@ defimpl Digger, for: BitString do
   end
 
   defp uppercase_first_for_upcase(string, type: :key, key_transform: :upper, value_transform: _) do
-    remainder = String.slice(string, 1..-1)
+    remainder = String.slice(string, 1..-1//-1)
 
     string
     |> String.first()

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Digger.Mixfile do
     [
       app: :digger,
       version: "3.0.0",
-      elixir: ">= 1.9.0",
+      elixir: ">= 1.12.0",
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
       description: description(),


### PR DESCRIPTION
- Use Kernel macro available since 1.12 (https://hexdocs.pm/elixir/1.12.0/Kernel.html#..///3)